### PR TITLE
Don't force inlining of long form of getNthWord

### DIFF
--- a/Data/Digest/Pure/MD5.hs
+++ b/Data/Digest/Pure/MD5.hs
@@ -241,13 +241,13 @@ applyMD5Rounds (MD5Par a b c d) w = {-# SCC "applyMD5Rounds" #-}
 
 #ifdef FastWordExtract
 getNthWord n b = inlinePerformIO (unsafeUseAsCString b (flip peekElemOff n . castPtr))
+{-# INLINE getNthWord #-}
 #else
 getNthWord :: Int -> B.ByteString -> Word32
 getNthWord n = right . G.runGet G.getWord32le . B.drop (n * sizeOf (undefined :: Word32))
   where
   right x = case x of Right y -> y
 #endif
-{-# INLINE getNthWord #-}
 
 ----- Some quick and dirty instances follow -----
 


### PR DESCRIPTION
`getNthWord` has two implementations. While the implementation used when `FastWordExtract` is set is quite lean and perhaps worth inlining, the other implementation (used, among other cases, in the case of ARM targets) is far too large. This results in the simplifier exploding. Don't require inlining of the non-`FastWordExtract` case.