### PR TITLE
Export a md5DigestBytes function to get access to the raw bytes

### DIFF
--- a/Data/Digest/Pure/MD5.hs
+++ b/Data/Digest/Pure/MD5.hs
@@ -31,6 +31,7 @@ module Data.Digest.Pure.MD5
         , md5
         , md5Update
         , md5Finalize
+        , md5DigestBytes
         -- * Crypto-API interface
         , Hash(..)
         ) where
@@ -39,6 +40,9 @@ import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as L
 import Data.ByteString.Unsafe (unsafeDrop,unsafeUseAsCString)
 import Data.ByteString.Internal
+#if MIN_VERSION_binary(0,8,3)
+import Data.ByteString.Builder.Extra as B
+#endif
 import Data.Bits
 import Data.List
 import Data.Word
@@ -249,19 +253,42 @@ getNthWord n = right . G.runGet G.getWord32le . B.drop (n * sizeOf (undefined ::
   right x = case x of Right y -> y
 #endif
 
+-- | The raw bytes of an 'MD5Digest'. It is always 16 bytes long.
+--
+-- You can also use the 'Binary' or 'S.Serialize' instances to output the raw
+-- bytes. Alternatively you can use 'show' to prodce the standard hex
+-- representation.
+--
+md5DigestBytes :: MD5Digest -> B.ByteString
+md5DigestBytes (MD5Digest h) = md5PartialBytes h
+
+md5PartialBytes :: MD5Partial -> B.ByteString
+md5PartialBytes =
+    toBs . (put :: MD5Partial -> Put)
+  where
+    toBs :: Put -> B.ByteString
+#if MIN_VERSION_binary(0,8,3)
+    -- with later binary versions we can control the buffer size precisely:
+    toBs = L.toStrict
+         . B.toLazyByteStringWith (B.untrimmedStrategy 16 0) L.empty
+         . execPut
+#else
+    toBs = B.concat . L.toChunks . runPut
+    -- note L.toStrict is only in newer bytestring versions
+#endif
+
 ----- Some quick and dirty instances follow -----
 
 instance Show MD5Digest where
     show (MD5Digest h) = show h
 
 instance Show MD5Partial where
-  show (MD5Par a b c d) =
-    let bs = runPut $ putWord32be d >> putWord32be c >>
-                      putWord32be b >> putWord32be a
+  show md5par =
+    let bs = md5PartialBytes md5par
     in foldl' (\str w -> let cx = showHex w str
                          in if length cx < length str + 2
                                  then '0':cx
-                                else cx) "" (L.unpack bs)
+                                else cx) "" (B.unpack (B.reverse bs))
 
 instance Binary MD5Digest where
     put (MD5Digest p) = put p


### PR DESCRIPTION
So I started writing this addition because although I'm a long-time user of this package (we use it in the `hackage-server`) I'd not realised that we can actually get the raw bytes of the 'MD5Digest' in the standard form. I thought the API prevented us from getting access to the raw bytes, that we could only use `show` to get the hex.

I assumed the `Binary` and `Serialise` instances were for serialisation. This is not an unreasonable assumption in general since that's what they're for, but also from an inspection of the code it looks like they don't produce the format we would need, since if we compare the show and binary instances, one uses `putWord32be` and the other `putWord32le`. So a casual inspection indicates that the binary instance is in the reverse order for what we would need if say we wanted to produce base64 rather than base16 encoding of the digest (since we can reasonably assume that the show impl that produces hex of course does it in the right order). But no! No actually on very close inspection the show instance actually reverses the bytes on output, so it also reverses the bytes when putting them into the buffer! Now I didn't notice that little gotcha until I'd written this new code and found I was producing the hex output in the wrong order.

So having realised all this, technically speaking this patch is redundant, however in practice given that even expert users cannot figure out the API then I think this (or something similar) is called for, even if it only serves as documentation.

So this patch adds md5DigestBytes :: MD5Digest -> B.ByteString and haddock docs to point out the other options, of Show, Binary or Serialise.

It also (optionally) takes advantage of binary-0.8.3+ support to control the buffer output size which makes it rather less wasteful (the default initial buffer size for binary and I presume also for cereal is tuned for large multi-kb outputs).