### PR TITLE
Support bytestring-0.11

### DIFF
--- a/Data/Digest/Pure/MD5.hs
+++ b/Data/Digest/Pure/MD5.hs
@@ -141,7 +141,15 @@ performMD5Update par@(MD5Par !a !b !c !d) !bs =
 {-# INLINE performMD5Update #-}
 
 isAligned :: ByteString -> Bool
+#if !MIN_VERSION_bytestring(0,11,0)
 isAligned (PS _ off _) = off `rem` 4 == 0
+#else
+isAligned = const True
+-- This is semantically equivalent to the definition above, because
+-- in bytestring-0.11 offset is always 0. Note that neither definition checks
+-- that a pointer (the first field of 'PS') is aligned. Anyways 'isAligned'
+-- is used for optimization purposes only and does not affect correctness.
+#endif
 
 applyMD5Rounds :: MD5Partial -> ByteString -> MD5Partial
 applyMD5Rounds (MD5Par a b c d) w = {-# SCC "applyMD5Rounds" #-}

--- a/pureMD5.cabal
+++ b/pureMD5.cabal
@@ -12,7 +12,6 @@ stability:	stable
 build-type:	Simple
 cabal-version:	>= 1.10
 tested-with:	GHC == 7.10.3
-extra-source-files: Test/MD5.hs
 
 flag test
   description: Build a test program


### PR DESCRIPTION
`bytestring-0.11` provides a backward compatible [pattern synonym `PS`](http://hackage.haskell.org/package/bytestring-0.11.0.0/docs/Data-ByteString-Internal.html#t:ByteString) for GHC >= 8.0, but older GHCs require the proposed patch to build.

Note that `isAligned` does not take into account an unaligned foreign pointer. While I have preserved this peculiarity, I'd rather suggest scrapping the optimization altogether. It would be desirable do not depend on `bytestring` internal representation at all. 